### PR TITLE
Build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: all clean install dist
 
+# Top directory for building complete system, fall back to this directory
+ROOTDIR    ?= $(shell pwd)
+
 VERSION = 1.0-beta1
 NAME    = phytool
 PKG     = $(NAME)-$(VERSION)
@@ -7,18 +10,20 @@ ARCHIVE = $(PKG).tar.xz
 APPLETS = mv6tool
 
 PREFIX ?= /usr/local/
-LIBS    = 
-CC      = gcc
-CFLAGS  = -g -Wall -Wextra
+LDLIBS  = 
+CFLAGS  = -W -Wall -Wextra
+CFLAGS += -g
 
 objs = $(patsubst %.c, %.o, $(wildcard *.c))
 hdrs = $(wildcard *.h)
 
 %.o: %.c $(hdrs) Makefile
+	@printf "  CC      $(subst $(ROOTDIR)/,,$(shell pwd)/$@)\n"
 	@$(CROSS_COMPILE)$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -c $< -o $@
 
 phytool: $(objs)
-	@$(CROSS_COMPILE)$(CC) $(objs) -Wall $(LIBS) -o $@
+	@printf "  CC      $(subst $(ROOTDIR)/,,$(shell pwd)/$@)\n"
+	@$(CROSS_COMPILE)$(CC) $(LDLIBS) -o $@ $^
 
 all: phytool
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
-.PHONY: all clean install
+.PHONY: all clean install dist
 
+VERSION = 1.0-beta1
+NAME    = phytool
+PKG     = $(NAME)-$(VERSION)
+ARCHIVE = $(PKG).tar.xz
 APPLETS = mv6tool
 
 PREFIX ?= /usr/local/
@@ -21,6 +25,11 @@ all: phytool
 clean:
 	@rm -f *.o
 	@rm -f $(TARGET)
+
+dist:
+	@echo "Creating $(ARCHIVE), with $(ARCHIVE).md5 in parent dir ..."
+	@git archive --format=tar --prefix=$(PKG)/ v$(VERSION) | xz >../$(ARCHIVE)
+	@(cd .. && md5sum $(ARCHIVE) > $(ARCHIVE).md5)
 
 install: phytool
 	@cp phytool $(DESTDIR)/$(PREFIX)/bin/


### PR DESCRIPTION
This pull request adds a `make dist` feature to the Makefile to build release tarballs from.
Simply update the Makefile with the new release version, commit and tag with `vX.Y`
before calling `make dist`.

There is also a minor cleanup/integration patch included.
