### PR TITLE
Makefile: Honor LDFLAGS variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ hdrs = $(wildcard *.h)
 
 phytool: $(objs)
 	@printf "  CC      $(subst $(ROOTDIR)/,,$(shell pwd)/$@)\n"
-	@$(CC) $(LDLIBS) -o $@ $^
+	@$(CC) $(LDFLAGS) $(LDLIBS) -o $@ $^
 
 all: phytool
 


### PR DESCRIPTION
Passing $(LDFLAGS) to the linker is important for cross-compile environments.
OpenEmbedded builds will display QA errors like this:
... QA Issue: No GNU_HASH in the elf binary ... [ldflags]

Signed-off-by: Mike Looijmans mike.looijmans@topic.nl
