### PR TITLE
Begin work to get phytool ready for Fedora inclusion.

### DIFF
--- a/phytool.c
+++ b/phytool.c
@@ -275,13 +275,19 @@ static int mv6tool_parse_loc_if(char *dev, char *addr, char *reg,
 
 	strncpy(loc->ifnam, dev, IFNAMSIZ - 1);
 
-	asprintf(&path, "/sys/class/net/%s/phys_switch_id", dev);
+	err = asprintf(&path, "/sys/class/net/%s/phys_switch_id", dev);
+	if (err == -1)
+		return -ENOMEM;
+
 	err = sysfs_readu(path, &phy_port);
 	free(path);
 	if (err)
 		return -ENOSYS;
 
-	asprintf(&path, "/sys/class/net/%s/phys_port_id", dev);
+	err = asprintf(&path, "/sys/class/net/%s/phys_port_id", dev);
+	if (err == -1)
+		return -ENOMEM;
+
 	err = sysfs_readu(path, &phy_dev);
 	free(path);
 	if (err)


### PR DESCRIPTION
- Fedora and other distros add a lot of flags to uncover possible problems with code. Added in an error check on asprintf as it could fail and cause problems.