### PR TITLE
Fedora spec02

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,13 @@ clean:
 	@rm -f $(TARGET)
 
 dist:
-	@echo "Creating $(ARCHIVE), with $(ARCHIVE).md5 in parent dir ..."
+	@echo "Creating $(ARCHIVE), with $(ARCHIVE).sha512 in parent dir ..."
 	@git archive --format=tar --prefix=$(PKG)/ v$(VERSION) | xz >../$(ARCHIVE)
-	@(cd .. && md5sum $(ARCHIVE) > $(ARCHIVE).md5)
+	@(cd .. && sha5125sum $(ARCHIVE) > $(ARCHIVE).sha512)
 
 install: phytool
-	@cp phytool $(DESTDIR)/$(PREFIX)/bin/
+	@mkdir -p $(DESTDIR)/$(PREFIX)/bin/
+	@cp -p phytool $(DESTDIR)/$(PREFIX)/bin/
 	@for app in $(APPLETS); do \
 		ln -sf phytool $(DESTDIR)/$(PREFIX)/bin/$$app; \
 	done

--- a/phytool.c
+++ b/phytool.c
@@ -275,13 +275,19 @@ static int mv6tool_parse_loc_if(char *dev, char *addr, char *reg,
 
 	strncpy(loc->ifnam, dev, IFNAMSIZ - 1);
 
-	asprintf(&path, "/sys/class/net/%s/phys_switch_id", dev);
+	err = asprintf(&path, "/sys/class/net/%s/phys_switch_id", dev);
+	if (err == -1)
+		return -ENOMEM;
+
 	err = sysfs_readu(path, &phy_port);
 	free(path);
 	if (err)
 		return -ENOSYS;
 
-	asprintf(&path, "/sys/class/net/%s/phys_port_id", dev);
+	err = asprintf(&path, "/sys/class/net/%s/phys_port_id", dev);
+	if (err == -1)
+		return -ENOMEM;
+
 	err = sysfs_readu(path, &phy_dev);
 	free(path);
 	if (err)


### PR DESCRIPTION
When building the package as an RPM, I found that the PREFIX/bin didn't exist [and found it also in a different system.] so I added a -p to try and make it if it doesn't exist already. 
Also found that the cp didn't preserve certain information on the copy which caused both the debuginfo tooling to fail and required permissions to be explicitely set on the file by the package. Reviewer mentioned that a `cp -p` would fix this so I have added that also. https://bugzilla.redhat.com/show_bug.cgi?id=2258110