### PR TITLE
Avoid %#x printf pattern

### DIFF
--- a/phytool.c
+++ b/phytool.c
@@ -356,7 +356,7 @@ static int phytool_read(struct applet *a, int argc, char **argv)
 	if (val < 0)
 		return 1;
 
-	printf("%#.4x\n", val);
+	printf("0x%.4x\n", val);
 	return 0;
 }
 

--- a/print_mv6.c
+++ b/print_mv6.c
@@ -39,7 +39,7 @@ static const char *mv6_model_str(uint16_t id)
 		return "mv88e6352";
 	}
 
-	snprintf(str, sizeof(str), "UNKNOWN(%#.4x)", id);
+	snprintf(str, sizeof(str), "UNKNOWN(0x%.4x)", id);
 	return str;
 }
 
@@ -60,7 +60,7 @@ static const char *mv6_dev_str(uint16_t dev)
 	else if (dev == 0x1d)
 		return "global:3";
 	else
-		snprintf(str, sizeof(str), "port:RESERVED(%#.2x)", dev);
+		snprintf(str, sizeof(str), "port:RESERVED(0x%.2x)", dev);
 
 	return str;
 }
@@ -89,7 +89,7 @@ static void mv6_port_ps(uint16_t val, int indent)
 		mult--;
 	}
 
-	printf("%*smv6: reg:PS(0x00) val:%#.4x\n", indent, "", val);
+	printf("%*smv6: reg:PS(0x00) val:0x%.4x\n", indent, "", val);
 
 	print_attr_name("flags", indent + INDENT);
 	print_bool("pause-en", val & 0x8000);
@@ -116,7 +116,7 @@ static void mv6_port_ps(uint16_t val, int indent)
 	print_attr_name("speed", indent + INDENT);
 	printf("%d-%s\n", speed, (val & 0x0400)? "full" : "half");
 	print_attr_name("mode", indent + INDENT);
-	printf("%#x\n", val & 0xf);
+	printf("0x%x\n", val & 0xf);
 }
 
 static const char *mv6_egress_mode_str[] = {
@@ -164,7 +164,7 @@ static void mv6_port_pc(uint16_t val, int indent)
 		mult--;
 	}
 
-	printf("%*smv6: reg:PC(0x04) val:%#.4x\n", indent, "", val);
+	printf("%*smv6: reg:PC(0x04) val:0x%.4x\n", indent, "", val);
 
 	print_attr_name("flags", indent + INDENT);
 	print_bool("router-header", val & 0x0800);
@@ -243,7 +243,7 @@ int mv6_port_one(const struct loc *loc, int indent, struct mv6_port_desc *pd)
 		return val;
 
 	if (loc->reg > 0x1f || !pd || !pd->printer[loc->reg])
-		printf("%*smv6: reg:%#.2x val:%#.4x\n", indent, "",
+		printf("%*smv6: reg:0x%.2x val:0x%.4x\n", indent, "",
 		       loc->reg, val);
 	else
 		pd->printer[loc->reg](val, indent);

--- a/print_phy.c
+++ b/print_phy.c
@@ -55,7 +55,7 @@ static void ieee_bmcr(uint16_t val, int indent)
 	if (val & BMCR_SPEED1000)
 		speed = 1000;
 
-	printf("%*sieee-phy: reg:BMCR(0x00) val:%#.4x\n", indent, "", val);
+	printf("%*sieee-phy: reg:BMCR(0x00) val:0x%.4x\n", indent, "", val);
 
 	print_attr_name("flags", indent + INDENT);
 	print_bool("reset", val & BMCR_RESET);
@@ -85,7 +85,7 @@ static void ieee_bmcr(uint16_t val, int indent)
 
 static void ieee_bmsr(uint16_t val, int indent)
 {
-	printf("%*sieee-phy: reg:BMSR(0x01) val:%#.4x\n", indent, "", val);
+	printf("%*sieee-phy: reg:BMSR(0x01) val:0x%.4x\n", indent, "", val);
 
 	print_attr_name("capabilities", indent + INDENT);
 	print_bool("100-b4", val & BMSR_100BASE4);
@@ -145,7 +145,7 @@ static int ieee_one(const struct loc *loc, int indent)
 		return val;
 
 	if (loc->reg > 0x1f || !ieee_reg_printers[loc->reg])
-		printf("%*sieee-phy: reg:%#.2x val:%#.4x\n", indent, "",
+		printf("%*sieee-phy: reg:0x%.2x val:0x%.4x\n", indent, "",
 		       loc->reg, val);
 	else
 		ieee_reg_printers[loc->reg](val, indent);
@@ -160,7 +160,7 @@ int print_phy_ieee(const struct loc *loc, int indent)
 	if (loc->reg != REG_SUMMARY)
 		return ieee_one(loc, indent);
 
-	printf("%*sieee-phy: id:%#.8x\n\n", indent, "", phy_id(loc));
+	printf("%*sieee-phy: id:0x%.8x\n\n", indent, "", phy_id(loc));
 
 	loc_sum.reg = 0;
 	ieee_one(&loc_sum, indent + INDENT);


### PR DESCRIPTION
The alternate form pattern %#x will not add the 0x prefix when the value is 0, leading to inconsistent output. This behavior is not documented in the linux-manpages page for printf, however both glibc and musl agree on it.